### PR TITLE
Add build workflow for Linux and macOS builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ name: Build and upload artifacts (linux/amd64 and darwin/arm64)
 on:
   push:
     branches: ["**"]
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,51 @@
+name: Build and upload artifacts (linux/amd64 and darwin/arm64)
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download dependencies
+        run: go get ./...
+
+      - name: Build (${{ matrix.goos }}-${{ matrix.goarch }})
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "0"
+        run: |
+          mkdir -p dist
+          echo "Building for $GOOS/$GOARCH"
+          out="dist/csvdiff-${GOOS}-${GOARCH}"
+          go build -o "$out"
+
+      - name: Upload artifact (${{ matrix.goos }}-${{ matrix.goarch }})
+        uses: actions/upload-artifact@v4
+        with:
+          name: csvdiff-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/csvdiff-${{ matrix.goos }}-${{ matrix.goarch }}
+          if-no-files-found: error
+          retention-days: 14

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,4 @@ require (
 	github.com/stretchr/testify v1.8.4
 )
 
-go 1.24.1
+go 1.25.4

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,4 @@ require (
 	github.com/stretchr/testify v1.8.4
 )
 
-go 1.13
+go 1.24.1


### PR DESCRIPTION
### Description

This pull request introduces a GitHub Actions workflow for building and uploading artifacts for:
- Linux (amd64)
- macOS (arm64)

Additionally, it updates the Go version to 1.25.4.

Closes https://knacktech.atlassian.net/browse/CORE-4212
